### PR TITLE
Update flight type descriptions for Passenger, Military, Cargo, and Private Flights

### DIFF
--- a/src/main/java/Flight/FlightTypes/CargoFlight.java
+++ b/src/main/java/Flight/FlightTypes/CargoFlight.java
@@ -5,7 +5,7 @@ import Flight.Flight;
 public class CargoFlight extends Flight {
     @Override
     public String getType() {
-        return "Flight.FlightTypes.CargoFlight";
+        return "Cargo Flight";
     }
 
     public CargoFlight(String flightNumber) {

--- a/src/main/java/Flight/FlightTypes/MilitaryFlight.java
+++ b/src/main/java/Flight/FlightTypes/MilitaryFlight.java
@@ -5,7 +5,7 @@ import Flight.Flight;
 public class MilitaryFlight extends Flight {
     @Override
     public String getType() {
-        return "Flight.FlightTypes.MilitaryFlight";
+        return "Military Flight";
     }
 
     @Override

--- a/src/main/java/Flight/FlightTypes/PassengerFlight.java
+++ b/src/main/java/Flight/FlightTypes/PassengerFlight.java
@@ -5,7 +5,7 @@ import Flight.Flight;
 public class PassengerFlight extends Flight {
     @Override
     public String getType() {
-        return "Flight.FlightTypes.PassengerFlight";
+        return "Passenger Flight";
     }
 
     public PassengerFlight(String flightNumber) {

--- a/src/main/java/Flight/FlightTypes/PrivateFlight.java
+++ b/src/main/java/Flight/FlightTypes/PrivateFlight.java
@@ -9,6 +9,6 @@ public class PrivateFlight extends Flight {
 
     @Override
     public String getType() {
-        return "Private Flight.Flight";
+        return "Private Flight";
     }
 }

--- a/src/test/java/AutomatedTest.java
+++ b/src/test/java/AutomatedTest.java
@@ -19,13 +19,13 @@ public class AutomatedTest {
     @Test
     void testFlightCreation() {
         // Test passenger flight
-        Assertions.assertEquals("Flight.FlightTypes.PassengerFlight", passengerFlight.getType());
+        Assertions.assertEquals("Passenger Flight", passengerFlight.getType());
         Assertions.assertEquals("PA123", passengerFlight.getFlightNumber());
         Assertions.assertEquals("On ground/Runway", passengerFlight.getState());
         Assertions.assertEquals(100, passengerFlight.getFuel());
 
         // Test military flight
-        Assertions.assertEquals("Flight.FlightTypes.MilitaryFlight", militaryFlight.getType());
+        Assertions.assertEquals("Military Flight", militaryFlight.getType());
         Assertions.assertEquals("MIL456", militaryFlight.getFlightNumber());
     }
 
@@ -84,8 +84,8 @@ public class AutomatedTest {
         Flight cargoFlight = FlightFactory.createFlight(FlightType.CARGO, "CG789");
         Flight privateFlight = FlightFactory.createFlight(FlightType.PRIVATE, "PV101");
         
-        Assertions.assertEquals("Flight.FlightTypes.CargoFlight", cargoFlight.getType());
-        Assertions.assertEquals("Private Flight.Flight", privateFlight.getType());
+        Assertions.assertEquals("Cargo Flight", cargoFlight.getType());
+        Assertions.assertEquals("Private Flight", privateFlight.getType());
     }
 
     @Test


### PR DESCRIPTION
This pull request includes changes to the `getType` method in various flight type classes to return more user-friendly strings.

Changes to `getType` method:

* [`src/main/java/Flight/FlightTypes/CargoFlight.java`](diffhunk://#diff-5f97f145faf2aa0876ed94f03ffec38098c18dce982bce34ca8e388b424564b9L8-R8): Updated the `getType` method to return "Cargo Flight" instead of "Flight.FlightTypes.CargoFlight".
* [`src/main/java/Flight/FlightTypes/MilitaryFlight.java`](diffhunk://#diff-a40243e5459b318e92f7edcad994b98fc72a9ef9440e75657d0020960cdd9c98L8-R8): Updated the `getType` method to return "Military Flight" instead of "Flight.FlightTypes.MilitaryFlight".
* [`src/main/java/Flight/FlightTypes/PassengerFlight.java`](diffhunk://#diff-555333e3f896b05447356f1b99260304d2a497f9b2849f2d7701b771c9f95c64L8-R8): Updated the `getType` method to return "Passenger Flight" instead of "Flight.FlightTypes.PassengerFlight".
* [`src/main/java/Flight/FlightTypes/PrivateFlight.java`](diffhunk://#diff-378a854d08cbc3b53678033290f48a18255acdad2997f21f90fa7849284a2809L12-R12): Updated the `getType` method to return "Private Flight" instead of "Private Flight.Flight".

Resolving issue caused by modularizing to packages by making getType() functions return correct words