### PR TITLE
Added colours to enum

### DIFF
--- a/src/main/java/views/ConsoleColour.java
+++ b/src/main/java/views/ConsoleColour.java
@@ -1,0 +1,20 @@
+package views;
+
+public enum ConsoleColour {
+    RESET("\033[0m"),
+    RED("\033[0;31m"),
+    GREEN("\033[0;92m"),
+    BLUE("\033[0;34m"),
+    YELLOW("\033[0;93m"),
+    WHITE("\033[0;97m");
+
+    private final String code;
+
+    ConsoleColour(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/views/ConsoleLogger.java
+++ b/src/main/java/views/ConsoleLogger.java
@@ -6,12 +6,6 @@ import java.util.logging.Logger;
 
 public class ConsoleLogger {
     public static final Logger logger = Logger.getLogger(ConsoleLogger.class.getName());
-    private static final String RESET = "\033[0m";
-    private static final String RED = "\033[0;31m";
-    private static final String GREEN = "\033[0;92m";
-    private static final String BLUE = "\033[0;34m";
-    private static final String YELLOW = "\033[0;93m";
-    private static final String WHITE = "\033[0;97m";
     private static final String FORMAT = "%s%s%s";
 
     static {
@@ -23,37 +17,37 @@ public class ConsoleLogger {
 
     public static void logError(String message) {
         if (logger.isLoggable(Level.SEVERE)) {
-            logger.log(Level.SEVERE, String.format(FORMAT, RED, "ERROR: " + message, RESET));
+            logger.log(Level.SEVERE, String.format(FORMAT, ConsoleColour.RED.getCode(), "ERROR: " + message, ConsoleColour.RESET.getCode()));
         }
     }
 
     public static void logStandard(String message) {
         if (logger.isLoggable(Level.INFO)) {
-            logger.log(Level.INFO, String.format(FORMAT, WHITE, message, RESET));
+            logger.log(Level.INFO, String.format(FORMAT, ConsoleColour.WHITE.getCode(), message, ConsoleColour.RESET.getCode()));
         }
     }
 
     public static void logSuccess(String message) {
         if (logger.isLoggable(Level.INFO)) {
-            logger.log(Level.INFO, String.format(FORMAT, GREEN, message, RESET));
+            logger.log(Level.INFO, String.format(FORMAT, ConsoleColour.GREEN.getCode(), message, ConsoleColour.RESET.getCode()));
         }
     }
 
     public static void logInfo(String message) {
         if (logger.isLoggable(Level.INFO)) {
-            logger.log(Level.INFO, String.format(FORMAT, BLUE, message, RESET));
+            logger.log(Level.INFO, String.format(FORMAT, ConsoleColour.BLUE.getCode(), message, ConsoleColour.RESET.getCode()));
         }
     }
 
     public static void logWarning(String message) {
         if (logger.isLoggable(Level.WARNING)) {
-            logger.log(Level.WARNING, String.format(FORMAT, YELLOW, "WARNING: " + message, RESET));
+            logger.log(Level.WARNING, String.format(FORMAT, ConsoleColour.YELLOW.getCode(), "WARNING: " + message, ConsoleColour.RESET.getCode()));
         }
     }
 
     public static void logTitle(String message) {
         if (logger.isLoggable(Level.INFO)) {
-            logger.log(Level.INFO, String.format(FORMAT, BLUE, message, RESET));
+            logger.log(Level.INFO, String.format(FORMAT, ConsoleColour.BLUE.getCode(), message, ConsoleColour.RESET.getCode()));
         }
     }
 
@@ -65,12 +59,12 @@ public class ConsoleLogger {
         if (logger.isLoggable(Level.INFO)) {
             StringBuilder optionsMessage = new StringBuilder();
             for (int i = 0; i < options.length; i++) {
-                optionsMessage.append(String.format(FORMAT, WHITE, String.format("%d. %s%n", i + 1, options[i]), RESET));
+                optionsMessage.append(String.format(FORMAT, ConsoleColour.WHITE.getCode(), String.format("%d. %s%n", i + 1, options[i]), ConsoleColour.RESET.getCode()));
             }
             if (Boolean.TRUE.equals(hasQuitOption)) {
-                optionsMessage.append(String.format("%sQ. Quit%s%n", YELLOW, RESET));
+                optionsMessage.append(String.format("%sQ. Quit%s%n", ConsoleColour.YELLOW.getCode(), ConsoleColour.RESET.getCode()));
             }
-            optionsMessage.append(String.format("%sChoose action: %s", GREEN, RESET));
+            optionsMessage.append(String.format("%sChoose action: %s", ConsoleColour.GREEN.getCode(), ConsoleColour.RESET.getCode()));
             logger.log(Level.INFO, optionsMessage.toString());
         }
     }


### PR DESCRIPTION
This pull request includes changes to improve the maintainability and readability of the `ConsoleLogger` class by introducing a new `ConsoleColour` enum. The most important changes are the creation of the `ConsoleColour` enum and the subsequent refactoring of the `ConsoleLogger` class to use this new enum.

Introduction of `ConsoleColour` enum:

* [`src/main/java/views/ConsoleColour.java`](diffhunk://#diff-09b2ed78391fbcb30264a6d605a93c91f89f3f536e0b6df331ad158dd7450fa5R1-R20): Created a new `ConsoleColour` enum to encapsulate ANSI color codes.

Refactoring `ConsoleLogger` class:

* [`src/main/java/views/ConsoleLogger.java`](diffhunk://#diff-829eb2c3029f8b1726051edc19b44a8728fe73efe92ef50c5d975a458754a694L9-L14): Removed hardcoded ANSI color codes and replaced them with the `ConsoleColour` enum values. [[1]](diffhunk://#diff-829eb2c3029f8b1726051edc19b44a8728fe73efe92ef50c5d975a458754a694L9-L14) [[2]](diffhunk://#diff-829eb2c3029f8b1726051edc19b44a8728fe73efe92ef50c5d975a458754a694L26-R50) [[3]](diffhunk://#diff-829eb2c3029f8b1726051edc19b44a8728fe73efe92ef50c5d975a458754a694L68-R67)