### PR TITLE
Nanda 2nd maintainability fix

### DIFF
--- a/src/main/java/factories/StateFactory.java
+++ b/src/main/java/factories/StateFactory.java
@@ -15,7 +15,7 @@ public class StateFactory {
         };
     }
 
-    private StateFactory() {
+    public StateFactory() {
         throw new IllegalStateException("Utility class");
     }
 }

--- a/src/main/java/factories/StateFactory.java
+++ b/src/main/java/factories/StateFactory.java
@@ -1,0 +1,21 @@
+package factories;
+
+import models.states.FlightState;
+import models.states.InAirState;
+import models.states.LandingModeState;
+import models.states.OnRunwayState;
+
+public class StateFactory {
+    public static FlightState getState(String stateName) {
+        return switch (stateName) {
+            case "In the air" -> new InAirState();
+            case "Landing mode" -> new LandingModeState();
+            case "On ground/Runway" -> new OnRunwayState();
+            default -> throw new IllegalArgumentException("Unknown state: " + stateName);
+        };
+    }
+
+    private StateFactory() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/src/main/java/models/states/FlightState.java
+++ b/src/main/java/models/states/FlightState.java
@@ -1,13 +1,18 @@
 package models.states;
 
-import models.flight.Flight;
+    import factories.StateFactory;
+    import models.flight.Flight;
 
-public interface FlightState {
-    void takeOff(Flight flight);
+    public interface FlightState {
+        void takeOff(Flight flight);
 
-    void land(Flight flight);
+        void land(Flight flight);
 
-    void hold(Flight flight);
+        void hold(Flight flight);
 
-    String getStateName();
-}
+        String getStateName();
+
+        default FlightState getNextState(String stateName) {
+            return StateFactory.getState(stateName);
+        }
+    }

--- a/src/main/java/models/states/InAirState.java
+++ b/src/main/java/models/states/InAirState.java
@@ -12,7 +12,7 @@ public class InAirState implements FlightState {
     @Override
     public void land(Flight flight) {
         ConsoleLogger.logSuccess("Transitioning to landing now");
-        flight.setState(new LandingModeState());
+        flight.setState(getNextState("Landing mode"));
     }
 
     @Override
@@ -24,6 +24,4 @@ public class InAirState implements FlightState {
     public String getStateName() {
         return "In the air";
     }
-
-
 }

--- a/src/main/java/models/states/LandingModeState.java
+++ b/src/main/java/models/states/LandingModeState.java
@@ -4,7 +4,6 @@ import models.flight.Flight;
 import views.ConsoleLogger;
 
 public class LandingModeState implements FlightState {
-
     @Override
     public void takeOff(Flight flight) {
         ConsoleLogger.logError("Cannot take off while landing. Do you have a pilot's licence?");
@@ -13,13 +12,13 @@ public class LandingModeState implements FlightState {
     @Override
     public void land(Flight flight) {
         ConsoleLogger.logSuccess("Landing completed");
-        flight.setState(new OnRunwayState());
+        flight.setState(getNextState("On ground/Runway"));
     }
 
     @Override
     public void hold(Flight flight) {
         ConsoleLogger.logWarning("Aborting landing attempt, returning to previous altitude");
-        flight.setState(new InAirState());
+        flight.setState(getNextState("In the air"));
     }
 
     @Override

--- a/src/main/java/models/states/OnRunwayState.java
+++ b/src/main/java/models/states/OnRunwayState.java
@@ -4,11 +4,10 @@ import models.flight.Flight;
 import views.ConsoleLogger;
 
 public class OnRunwayState implements FlightState {
-
     @Override
     public void takeOff(Flight flight) {
         ConsoleLogger.logSuccess("Taxiing to take off");
-        flight.setState(new InAirState());
+        flight.setState(getNextState("In the air"));
     }
 
     @Override
@@ -25,6 +24,4 @@ public class OnRunwayState implements FlightState {
     public String getStateName() {
         return "On ground/Runway";
     }
-
-
 }

--- a/src/test/java/factoriesTest/StateFactoryTest.java
+++ b/src/test/java/factoriesTest/StateFactoryTest.java
@@ -1,0 +1,41 @@
+package factoriesTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import factories.StateFactory;
+import org.junit.jupiter.api.Test;
+import models.states.FlightState;
+import models.states.InAirState;
+import models.states.LandingModeState;
+import models.states.OnRunwayState;
+
+class StateFactoryTest {
+
+    @Test
+    void getState_returnsInAirState_whenStateNameIsInTheAir() {
+        FlightState state = StateFactory.getState("In the air");
+        assertInstanceOf(InAirState.class, state);
+    }
+
+    @Test
+    void getState_returnsLandingModeState_whenStateNameIsLandingMode() {
+        FlightState state = StateFactory.getState("Landing mode");
+        assertInstanceOf(LandingModeState.class, state);
+    }
+
+    @Test
+    void getState_returnsOnRunwayState_whenStateNameIsOnGroundRunway() {
+        FlightState state = StateFactory.getState("On ground/Runway");
+        assertInstanceOf(OnRunwayState.class, state);
+    }
+
+    @Test
+    void getState_throwsIllegalArgumentException_whenStateNameIsUnknown() {
+        assertThrows(IllegalArgumentException.class, () -> StateFactory.getState("Unknown state"));
+    }
+
+    @Test
+    void constructor_throwsIllegalStateException_whenCalled() {
+        assertThrows(IllegalStateException.class, StateFactory::new);
+    }
+}


### PR DESCRIPTION
This pull request introduces a `StateFactory` class to manage the creation of `FlightState` objects, simplifying state transitions in the flight states. It also refactors existing state transition logic to use this new factory.

Key changes include:

### Introduction of `StateFactory`:

* [`src/main/java/factories/StateFactory.java`](diffhunk://#diff-eada5eb0fbb8dc3809faaeaba69230c11e79adb5b2a34991f33d067fe579de7bR1-R21): Added a new `StateFactory` class to create instances of `FlightState` based on a given state name. This factory uses a switch expression to return the appropriate state object.

### Refactoring state transitions:

* [`src/main/java/models/states/FlightState.java`](diffhunk://#diff-06e1567519c1dd128006308735ee0ba1ee14b850bffcbbcab2ba12fe8733a901R14-R17): Added a default method `getNextState` to the `FlightState` interface, which uses the `StateFactory` to get the next state.

### Updates to state classes:

* [`src/main/java/models/states/InAirState.java`](diffhunk://#diff-a34bca7bf75838c6debad408519ad34e7d915b784e9e00c80877843410dc1f59L15-R15): Modified the `land` method to use `getNextState` for transitioning to `LandingModeState`.
* [`src/main/java/models/states/LandingModeState.java`](diffhunk://#diff-1d59508ec4252b8aad5119125fee68924cab46fc7703a68d67e420fa6bb11a17L16-R21): Updated the `land` and `hold` methods to use `getNextState` for transitioning to `OnRunwayState` and `InAirState`, respectively.
* [`src/main/java/models/states/OnRunwayState.java`](diffhunk://#diff-79f1c80e91ea6503738cbc9108b165f137b8e7b6d7d68a01f840aeafc681e6e6L7-R10): Changed the `takeOff` method to use `getNextState` for transitioning to `InAirState`.

### Purpose

The purpose of the PR is to remove the remaining 3 codesmells.